### PR TITLE
Replace spacefish with its successor, starship

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Looking to get started with fish? [Try it in your browser](https://rootnroll.com
 - [Pure](https://github.com/rafaelrinaldi/pure) - Port of [sindresorhus/pure](https://github.com/sindresorhus/pure) prompt.
 - [Mono](https://github.com/fishpkg/fish-prompt-mono) - No bells or whistles, minimal shell prompt.
 - [Metro](https://github.com/fishpkg/fish-prompt-metro) - Git-aware, space-conscious, powerline prompt.
-- [Spacefish](https://github.com/matchai/spacefish) - Space-themed prompt for astronauts.
+- [Starship](https://github.com/starship/starship) - Minimal, blazing fast, and extremely customizable prompt.
 - [Bobthefish](https://github.com/oh-my-fish/theme-bobthefish) - Robust, git-aware, powerline prompt.
 
 ### Commands, utilities, functions


### PR DESCRIPTION
Hey Jorge 👋

A quick PR to replace spacefish with its successor, starship.
Now that the two are in a similar place functionally, I think it makes sense to replace spacefish with the actively maintained prompt.

Cheers!